### PR TITLE
Fix possible 2 access messages on places

### DIFF
--- a/src/commands/place.ts
+++ b/src/commands/place.ts
@@ -30,9 +30,26 @@ export async function place (interaction:CommandInteraction) {
   }
 
   let externalDesc = ''
+  let accessMessage = ''
 
   if (data.isActive === false) {
     externalDesc += `${emojiUtils.private} **This place is currently private. Only the creator can join it.**\n`
+  } else {
+    switch (data.accessType) {
+      case 'everyone':
+        accessMessage = `${emojiUtils.public} **This place is currently joinable by everyone!**`
+        break
+      case 'purchase': {
+        const accessPrice = data.accessPrice || 0
+        accessMessage = `${emojiUtils.brick} **This place requires payment of ${accessPrice.toLocaleString()} bricks.**`
+        break
+      }
+      case 'whitelist':
+        accessMessage = `${emojiUtils.request} **This place is currently whitelisted.**`
+        break
+      default:
+        break
+    }
   }
 
   externalDesc += '\n'
@@ -41,24 +58,6 @@ export async function place (interaction:CommandInteraction) {
     externalDesc += '*No description set.*'
   } else {
     externalDesc += data.description
-  }
-
-  let accessMessage = ''
-
-  switch (data.accessType) {
-    case 'everyone':
-      accessMessage = `${emojiUtils.public} **This place is currently joinable by everyone!**`
-      break
-    case 'purchase': {
-      const accessPrice = data.accessPrice || 0
-      accessMessage = `${emojiUtils.brick} **This place requires payment of ${accessPrice.toLocaleString()} bricks.**`
-      break
-    }
-    case 'whitelist':
-      accessMessage = `${emojiUtils.request} **This place is currently whitelisted.**`
-      break
-    default:
-      break
   }
 
   const embed = new EmbedBuilder({


### PR DESCRIPTION
The old code would still show an accessMessage even if the place was completely private/inactive.
An example was found by @ItsLuiggiYahoo with this place ID: 5085
It would show:
🔓 This place is currently joinable by everyone!
🔒 This place is currently private. Only the creator can join it.

---
I am unable to run the bot locally so please make edits if the code doesn't work sorry