### PR TITLE
Add Store Owners Sub-Command

### DIFF
--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -12,7 +12,8 @@ async function fetchOwners (itemID: number, page: number): Promise<any[]> {
 function buildOwnersEmbed (ownersData: any[], page: number): EmbedBuilder {
   const ownersEmbed = new EmbedBuilder()
     .setTitle('Item Owners (' + ownersData.total + ')')
-    .setColor('#3498db')
+    .setColor('#FF5454')
+    .setThumbnail('thumbnailURL')
 
   const ownersContent = ownersData.inventories.map((owner: any) => {
     return `Serial #${owner.serial}. [${owner.user.username}](https://polytoria.com/users/${owner.user.id})`

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -1,8 +1,26 @@
-import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, CommandInteraction } from 'discord.js'
+import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, CommandInteraction, StringSelectMenuBuilder, ComponentType, BaseInteraction } from 'discord.js'
 import axios from 'axios'
 import { responseHandler } from '../utils/responseHandler.js'
 import { dateUtils } from '../utils/dateUtils.js'
 import emojiUtils from '../utils/emojiUtils.js'
+
+async function fetchOwners (itemID: number, page: number): Promise<any[]> {
+  const response = await axios.get(`https://api.polytoria.com/v1/store/${itemID}/owners?limit=10&page=${page}`)
+  return response.data
+}
+
+function buildOwnersEmbed (ownersData: any[], page: number): EmbedBuilder {
+  const ownersEmbed = new EmbedBuilder()
+    .setTitle('Item Owners (' + ownersData.total + ')')
+    .setColor('#3498db')
+
+  const ownersContent = ownersData.inventories.map((owner: any) => {
+    return `Serial #${owner.serial}. [${owner.user.username}](https://polytoria.com/users/${owner.user.id})`
+  })
+
+  ownersEmbed.setDescription(`> **Page ${page}/${ownersData.pages} **\n\n` + ownersContent.join('\n'))
+  return ownersEmbed
+}
 
 export async function store (interaction:CommandInteraction) {
   // @ts-expect-error
@@ -73,27 +91,147 @@ export async function store (interaction:CommandInteraction) {
     embed.addFields(
       {
         name: 'Price',
-        value: emojiUtils.brick + ' ' + data.price.toString(),
+        value: emojiUtils.brick + ' ' + data.price.toLocaleString(),
         inline: true
       },
       {
         name: 'Sales',
-        value: data.sales.toString(),
+        value: data.sales.toLocaleString(),
         inline: true
       }
     )
   }
 
-  const actionRow = new ActionRowBuilder<ButtonBuilder>()
-    .addComponents(
-      new ButtonBuilder()
-        .setURL(`https://polytoria.com/store/${data.id}`)
-        .setLabel('View on Polytoria')
-        .setStyle(ButtonStyle.Link)
-    )
+  const dropdown = new StringSelectMenuBuilder()
+    .setCustomId('dropdown_menu')
+    .setPlaceholder('Choose a store feature to view!')
+    .addOptions([
+      {
+        label: '👕 Item',
+        value: 'item_option'
+      },
+      {
+        label: '💼 Owners',
+        value: 'item_owners'
+      }
+    ])
 
-  await interaction.editReply({
+  const prevButton = new ButtonBuilder()
+    .setLabel('Previous')
+    .setStyle(ButtonStyle.Danger)
+    .setCustomId('prev_button')
+
+  const nextButton = new ButtonBuilder()
+    .setLabel('Next')
+    .setStyle(ButtonStyle.Success)
+    .setCustomId('next_button')
+
+  const actionRowDropdown = new ActionRowBuilder<StringSelectMenuBuilder>()
+    .addComponents(dropdown)
+
+  const reply = await interaction.editReply({
     embeds: [embed],
-    components: [actionRow]
+    components: [actionRowDropdown]
+  })
+
+  let ownersPage = 1
+  let selectedOption: string = 'item_option'
+
+  const collector = reply.createMessageComponentCollector({
+    componentType: ComponentType.SelectMenu,
+    filter: (messageInteraction: BaseInteraction) => (
+      messageInteraction.isStringSelectMenu() && messageInteraction.customId === 'dropdown_menu' &&
+      messageInteraction.user.id === interaction.user.id
+    ),
+    time: 60000
+  })
+
+  collector.on('collect', async (messageInteraction) => {
+    await messageInteraction.deferUpdate()
+
+    selectedOption = messageInteraction.values[0]
+
+    if (selectedOption === 'item_option') {
+      await interaction.editReply({
+        embeds: [embed],
+        components: [actionRowDropdown]
+      })
+    } else if (selectedOption === 'item_owners') {
+      const assetOwners = await fetchOwners(assetID, ownersPage)
+      const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage)
+
+      await interaction.editReply({
+        embeds: [newOwnersEmbed],
+        components: [
+          new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton),
+          actionRowDropdown
+        ]
+      })
+    }
+  })
+
+  const prevButtonCollector = reply.createMessageComponentCollector({
+    componentType: ComponentType.Button,
+    filter: (btnInteraction: BaseInteraction) => (
+      btnInteraction.isButton() &&
+      btnInteraction.customId === 'prev_button' &&
+      btnInteraction.user.id === interaction.user.id
+    ),
+    time: 60000
+  })
+
+  prevButtonCollector.on('collect', async (buttonInteraction) => {
+    try {
+      await buttonInteraction.deferUpdate()
+
+      if (selectedOption === 'item_owners' && ownersPage > 1) {
+        ownersPage--
+        const assetOwners = await fetchOwners(assetID, ownersPage)
+        const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage)
+
+        await interaction.editReply({
+          embeds: [newOwnersEmbed],
+          components: [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton),
+            actionRowDropdown
+          ]
+        })
+      }
+    } catch (error) {
+      console.error('Error handling interaction:', error)
+    }
+  })
+
+  const nextButtonCollector = reply.createMessageComponentCollector({
+    componentType: ComponentType.Button,
+    filter: (btnInteraction: BaseInteraction) => (
+      btnInteraction.isButton() &&
+      btnInteraction.customId === 'next_button' &&
+      btnInteraction.user.id === interaction.user.id
+    ),
+    time: 60000
+  })
+
+  nextButtonCollector.on('collect', async (buttonInteraction) => {
+    try {
+      await buttonInteraction.deferUpdate()
+
+      if (selectedOption === 'item_owners') {
+        ownersPage++
+        const assetOwners = await fetchOwners(assetID, ownersPage)
+        const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage)
+
+        console.log('next button clicked')
+        await interaction.editReply({
+          embeds: [newOwnersEmbed],
+          components: [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton),
+            actionRowDropdown
+          ]
+        })
+      }
+    } catch (error) {
+      console.error('Error handling interaction:', error)
+    }
   })
 }

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -4,18 +4,30 @@ import { responseHandler } from '../utils/responseHandler.js'
 import { dateUtils } from '../utils/dateUtils.js'
 import emojiUtils from '../utils/emojiUtils.js'
 
-async function fetchOwners (itemID: number, page: number): Promise<any[]> {
+interface OwnersData {
+  total: number;
+  inventories: {
+    serial: number;
+    user: {
+      username: string;
+      id: number;
+    };
+  }[];
+  pages: number;
+}
+
+async function fetchOwners (itemID: number, page: number): Promise<OwnersData> {
   const response = await axios.get(`https://api.polytoria.com/v1/store/${itemID}/owners?limit=10&page=${page}`)
   return response.data
 }
 
-function buildOwnersEmbed (ownersData: any[], page: number, thumbnail: string): EmbedBuilder {
+function buildOwnersEmbed (ownersData: OwnersData, page: number, thumbnail: string): EmbedBuilder {
   const ownersEmbed = new EmbedBuilder()
     .setTitle('Item Owners (' + ownersData.total + ')')
     .setColor('#FF5454')
     .setThumbnail(thumbnail)
 
-  const ownersContent = ownersData.inventories.map((owner: any) => {
+  const ownersContent = ownersData.inventories.map((owner) => {
     return `Serial #${owner.serial}. [${owner.user.username}](https://polytoria.com/users/${owner.user.id})`
   })
 
@@ -222,7 +234,6 @@ export async function store (interaction:CommandInteraction) {
         const assetOwners = await fetchOwners(assetID, ownersPage)
         const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage, thumbnailURL)
 
-        console.log('next button clicked')
         await interaction.editReply({
           embeds: [newOwnersEmbed],
           components: [

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -9,11 +9,11 @@ async function fetchOwners (itemID: number, page: number): Promise<any[]> {
   return response.data
 }
 
-function buildOwnersEmbed (ownersData: any[], page: number): EmbedBuilder {
+function buildOwnersEmbed (ownersData: any[], page: number, thumbnail: string): EmbedBuilder {
   const ownersEmbed = new EmbedBuilder()
     .setTitle('Item Owners (' + ownersData.total + ')')
     .setColor('#FF5454')
-    .setThumbnail('thumbnailURL')
+    .setThumbnail(thumbnail)
 
   const ownersContent = ownersData.inventories.map((owner: any) => {
     return `Serial #${owner.serial}. [${owner.user.username}](https://polytoria.com/users/${owner.user.id})`
@@ -159,7 +159,7 @@ export async function store (interaction:CommandInteraction) {
       })
     } else if (selectedOption === 'item_owners') {
       const assetOwners = await fetchOwners(assetID, ownersPage)
-      const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage)
+      const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage, thumbnailURL)
 
       await interaction.editReply({
         embeds: [newOwnersEmbed],
@@ -188,7 +188,7 @@ export async function store (interaction:CommandInteraction) {
       if (selectedOption === 'item_owners' && ownersPage > 1) {
         ownersPage--
         const assetOwners = await fetchOwners(assetID, ownersPage)
-        const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage)
+        const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage, thumbnailURL)
 
         await interaction.editReply({
           embeds: [newOwnersEmbed],
@@ -220,7 +220,7 @@ export async function store (interaction:CommandInteraction) {
       if (selectedOption === 'item_owners') {
         ownersPage++
         const assetOwners = await fetchOwners(assetID, ownersPage)
-        const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage)
+        const newOwnersEmbed = buildOwnersEmbed(assetOwners, ownersPage, thumbnailURL)
 
         console.log('next button clicked')
         await interaction.editReply({

--- a/src/commands/user/lookup.ts
+++ b/src/commands/user/lookup.ts
@@ -78,7 +78,7 @@ export async function lookUp (interaction: CommandInteraction) {
     badges += emojiUtils.plus + ' '
   }
 
-  const embed = new EmbedBuilder({
+  const embedInfo = {
     title: data.username + badges,
     url: `https://polytoria.com/users/${data.id}`,
     description: data.description,
@@ -128,7 +128,17 @@ export async function lookUp (interaction: CommandInteraction) {
         inline: true
       }
     ]
-  })
+  }
+
+  if (data.playing !== null) {
+      embedInfo.push({
+          name: 'Playing',
+          value: ':video_game: [' + data.playing.name + '](https://polytoria.com/places/' + data.playing.placeID + ')',
+          inline: true
+      })
+  }
+
+  const embed = new EmbedBuilder(embedInfo)
 
   const dropdown = new StringSelectMenuBuilder()
     .setCustomId('dropdown_menu')

--- a/src/commands/user/lookup.ts
+++ b/src/commands/user/lookup.ts
@@ -5,7 +5,12 @@ import { dateUtils } from '../../utils/dateUtils.js'
 import emojiUtils from '../../utils/emojiUtils.js'
 import { userUtils } from '../../utils/userUtils.js'
 
-async function fetchWallPosts (userID: number, page: number): Promise<any[]> {
+interface WallPostsResponse {
+  success: boolean;
+  data: any[];
+}
+
+async function fetchWallPosts (userID: number, page: number): Promise<WallPostsResponse> {
   const response = await axios.get(`https://polytoria.com/api/wall/${userID}?page=${page}`)
   return response.data
 }
@@ -151,7 +156,7 @@ export async function lookUp (interaction: CommandInteraction) {
       {
         label: '📝 Wall Posts',
         value: 'wall_posts_option'
-      },
+      }
     ])
 
   const prevButton = new ButtonBuilder()
@@ -196,7 +201,7 @@ export async function lookUp (interaction: CommandInteraction) {
       })
     } else if (selectedOption === 'wall_posts_option') {
       const wallPostsData = await fetchWallPosts(userID, wallPostsPage)
-      if (wallPostsData.success === undefined) {
+      if (wallPostsData.success) {
         const newWallPostsEmbed = buildWallPostsEmbed(wallPostsData.data)
 
         await interaction.editReply({
@@ -208,7 +213,7 @@ export async function lookUp (interaction: CommandInteraction) {
         })
       } else {
         const errorEmbed = new EmbedBuilder({
-          title: "Wall Posts",
+          title: 'Wall Posts',
           url: `https://polytoria.com/users/${data.id}`,
           description: "This user's wall is either private or restricted to friends-only.",
           color: 0xFF5454
@@ -274,7 +279,7 @@ export async function lookUp (interaction: CommandInteraction) {
       if (selectedOption === 'wall_posts_option' && wallPostsPage > 1) {
         wallPostsPage--
         const wallPostsData = await fetchWallPosts(userID, wallPostsPage)
-        const newWallPostsEmbed = buildWallPostsEmbed(wallPostsData)
+        const newWallPostsEmbed = buildWallPostsEmbed(wallPostsData.data)
 
         await interaction.editReply({
           embeds: [newWallPostsEmbed],
@@ -306,7 +311,7 @@ export async function lookUp (interaction: CommandInteraction) {
       if (selectedOption === 'wall_posts_option') {
         wallPostsPage++
         const wallPostsData = await fetchWallPosts(userID, wallPostsPage)
-        const newWallPostsEmbed = buildWallPostsEmbed(wallPostsData)
+        const newWallPostsEmbed = buildWallPostsEmbed(wallPostsData.data)
 
         await interaction.editReply({
           embeds: [newWallPostsEmbed],


### PR DESCRIPTION
- Added proper error handling when the user's wall is private/restricted to friends-only

- Bricks on the `/lookup [username]` command now show as a locale string with a comma to make it easier to read for some users

- Added a owners dropdown section to the `/store [item ID]` command

---

Ignore the "Add playing tag to lookup command" GitHub commit, I reverted those changes (I think) in one of the GitHub commits for this pull request. It has since been added by Star.