### PR TITLE
fix: package versioning

### DIFF
--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -8,7 +8,7 @@ interface PackageJson {
 
 function getVersion(): string {
   // Use import.meta.url for proper resolution in ES modules
-  const jsonPath = new URL('../package.json', import.meta.url);
+  const jsonPath = new URL('../../package.json', import.meta.url);
   const raw = readFileSync(jsonPath, 'utf-8');
   const pkg: PackageJson = JSON.parse(raw);
   return pkg.version ?? '0';

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,4 +1,18 @@
 import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, CommandInteraction } from 'discord.js'
+import { readFileSync } from 'fs';
+
+interface PackageJson {
+  version?: string;
+  [key: string]: any;
+}
+
+function getVersion(): string {
+  // Use import.meta.url for proper resolution in ES modules
+  const jsonPath = new URL('../package.json', import.meta.url);
+  const raw = readFileSync(jsonPath, 'utf-8');
+  const pkg: PackageJson = JSON.parse(raw);
+  return pkg.version ?? '0';
+}
 
 export async function info (interaction:CommandInteraction) {
   const invite = new ButtonBuilder()
@@ -20,7 +34,7 @@ export async function info (interaction:CommandInteraction) {
     .setURL('https://discord.com/api/oauth2/authorize?client_id=905979909049028649&permissions=414464724032&scope=bot')
     .setThumbnail('https://starmanthegamer.com/icon.png')
     .addFields(
-      { name: 'Version', value: `Currently running version: ${process.env.npm_package_version}` },
+      { name: 'Version', value: `Currently running version: ${getVersion()}` },
       { name: 'Contributed by:', value: 'baggy, DevPixels, Index, InsertSoda, and many more!', inline: true }
     )
     .setFooter({ text: 'Thank you for using Polytoria Community Bot!', iconURL: 'https://starmanthegamer.com/icon.png' })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 		"noEmit": false,
 		"target": "es2020",
 		"importHelpers": true,
-		"module": "es6",
+		"module": "es2020",
 		"skipLibCheck": false,
 		"esModuleInterop": true,
 		"outDir": "dist",


### PR DESCRIPTION
The previous code only worked if you launched the bot using npm, but if you launch using any other launchers / supervisors, it wont display the correct version.

Fixes by importing package.json and reading the version off from it.

- [X] The changes you've made are accurate and correct
- [ ] Made sure that the bot will build, run, and all commands are working.
- [X] Distinct changes for separate issues are in separate PRs (do not combine multiple issues into one PR)
- [ ] Ran ESlint to keep code in proper formatting - ``npm run lint``

WIP